### PR TITLE
modify_YOLO_object_loss

### DIFF
--- a/ML/Pytorch/object_detection/YOLO/loss.py
+++ b/ML/Pytorch/object_detection/YOLO/loss.py
@@ -82,7 +82,8 @@ class YoloLoss(nn.Module):
 
         object_loss = self.mse(
             torch.flatten(exists_box * pred_box),
-            torch.flatten(exists_box * target[..., 20:21]),
+            # To calculate confidenc score in paper, I think it should multiply iou value.
+            torch.flatten(exists_box * target[..., 20:21] * iou_maxes),
         )
 
         # ======================= #


### PR DESCRIPTION
First of all, Thank you very much. I can understand YOLO model easily because of your youtube and github code.

In the YOLO original paper, they predict confidence score. If the model is trained well, then the model prediction will close to IoU(Intersection over Union). However, in your code the model prediction will close to 1, if object is existed in the grid cell.
For this problem, I think the loss function(object loss) should be modified. 
In your code, it has already calculated IoU between prediction box and ground truth box. So the modification is going to be simple. Just multiply IoU value in target[...,20:21]. Becuase target[...,20:21] is 1, if the object is existed in the grid cell.  