### PR TITLE
Fix EfficientNet expand_conv

### DIFF
--- a/ML/Pytorch/CNN_architectures/pytorch_efficientnet.py
+++ b/ML/Pytorch/CNN_architectures/pytorch_efficientnet.py
@@ -80,7 +80,7 @@ class InvertedResidualBlock(nn.Module):
 
         if self.expand:
             self.expand_conv = CNNBlock(
-                in_channels, hidden_dim, kernel_size=3, stride=1, padding=1,
+                in_channels, hidden_dim, kernel_size=1, stride=1, padding=0,
             )
 
         self.conv = nn.Sequential(


### PR DESCRIPTION
Fixed the kernel_size of expand_conv in regard to https://github.com/aladdinpersson/Machine-Learning-Collection/issues/77
 tested all efficientnet versions with the foward passes and all return torch.size([4, 10]) as they should