### PR TITLE
Changed indexing of the label matrix to match how many classes exist

### DIFF
--- a/ML/Pytorch/object_detection/YOLO/dataset.py
+++ b/ML/Pytorch/object_detection/YOLO/dataset.py
@@ -73,16 +73,16 @@ class VOCDataset(torch.utils.data.Dataset):
             # If no object already found for specific cell i,j
             # Note: This means we restrict to ONE object
             # per cell!
-            if label_matrix[i, j, 20] == 0:
+            if label_matrix[i, j, self.C] == 0:
                 # Set that there exists an object
-                label_matrix[i, j, 20] = 1
+                label_matrix[i, j, self.C] = 1
 
                 # Box coordinates
                 box_coordinates = torch.tensor(
                     [x_cell, y_cell, width_cell, height_cell]
                 )
 
-                label_matrix[i, j, 21:25] = box_coordinates
+                label_matrix[i, j, (self.C + 1):(self.C + 5)] = box_coordinates
 
                 # Set one hot encoding for class_label
                 label_matrix[i, j, class_label] = 1


### PR DESCRIPTION
Noticed that the indexing of the dataset for the YOLO model would be incorrect and could return errors if not using 20 classes. Fix to make these indexes depend on the number of classes.