### PR TITLE
UNET self.ups alternative in forward pass

### DIFF
--- a/ML/Pytorch/image_segmentation/semantic_segmentation_unet/model.py
+++ b/ML/Pytorch/image_segmentation/semantic_segmentation_unet/model.py
@@ -52,17 +52,15 @@ class UNET(nn.Module):
             x = self.pool(x)
 
         x = self.bottleneck(x)
-        skip_connections = skip_connections[::-1]
 
-        for idx in range(0, len(self.ups), 2):
-            x = self.ups[idx](x)
-            skip_connection = skip_connections[idx//2]
+        for idx, skip_connection in enumerate(reversed(skip_connections)):
+            x = self.ups[2*idx](x)
 
             if x.shape != skip_connection.shape:
                 x = TF.resize(x, size=skip_connection.shape[2:])
 
             concat_skip = torch.cat((skip_connection, x), dim=1)
-            x = self.ups[idx+1](concat_skip)
+            x = self.ups[2*idx + 1](concat_skip)
 
         return self.final_conv(x)
 


### PR DESCRIPTION
Implemented alternative way to make skip connections work in forward pass for UNET model.

Instead of iterating with a step of 2 over `self.ups`, iterate over the `reversed(skip_connections)`.
The indices are adapted accordingly.

Changes come as a reaction to [PyTorch Image Segmentation Tutorial with U-NET: everything from scratch baby](https://www.youtube.com/watch?v=IHq1t7NxS8k&t=1300s)  at 16'00'' (love the video)

Hope it helps. Hope it's more intuitive as approach.