### PR TITLE
fixed 64x78 Image probllem

### DIFF
--- a/ML/Pytorch/GANs/4. WGAN-GP/train.py
+++ b/ML/Pytorch/GANs/4. WGAN-GP/train.py
@@ -33,7 +33,7 @@ LAMBDA_GP = 10
 
 transforms = transforms.Compose(
     [
-        transforms.Resize(IMAGE_SIZE),
+        transforms.Resize((IMAGE_SIZE, IMAGE_SIZE)),
         transforms.ToTensor(),
         transforms.Normalize(
             [0.5 for _ in range(CHANNELS_IMG)], [0.5 for _ in range(CHANNELS_IMG)]


### PR DESCRIPTION
While i was playing with WGAN-gp i faced up RunTime Error  that appeared in gradient_penalty function. It turns out transforms.Resize(64) sometimes produced images like 64x78, so change it to transforms.Resize((64, 64))