### PR TITLE
Update pytorch_rnn_gru_lstm.py

### DIFF
--- a/ML/Pytorch/Basics/pytorch_rnn_gru_lstm.py
+++ b/ML/Pytorch/Basics/pytorch_rnn_gru_lstm.py
@@ -159,5 +159,5 @@ def check_accuracy(loader, model):
     return num_correct / num_samples
 
 
-print(f"Accuracy on training set: {check_accuracy(train_loader, model)*100:2f}")
+print(f"Accuracy on training set: {check_accuracy(train_loader, model)*100:.2f}")
 print(f"Accuracy on test set: {check_accuracy(test_loader, model)*100:.2f}")


### PR DESCRIPTION
print(f"Accuracy on training set: {check_accuracy(train_loader, model)*100:2f}") This line had a missing "." for the number of decimals.