### PR TITLE
Fix the points parameter(N) not being used during data creation

### DIFF
--- a/ML/algorithms/neuralnetwork/utils.py
+++ b/ML/algorithms/neuralnetwork/utils.py
@@ -8,8 +8,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
-def create_dataset(N, K=2):
-    N = 100  # number of points per class
+def create_dataset(N=100, K=2):
     D = 2
     X = np.zeros((N * K, D))  # data matrix (each row = single example)
     y = np.zeros(N * K)  # class labels


### PR DESCRIPTION
The function used for data creation isn't using the parameter N, because it is being shadowed by "N=100" in the first line of the create_dataset function. I modified the function to use the value 100 for the number of points by default and take the value provided by the parameter N otherwise.
Below is an example of calling the function with `create_dataset(300, 3)` before the changes:
![before](https://github.com/user-attachments/assets/5fd3928a-365b-4561-968d-77e731c2dced)
And after changes:
![after](https://github.com/user-attachments/assets/8b54dcff-2da5-4a5f-b104-72eca65889e8)
