### PR TITLE
bug fix: remove unnecessary device transfer in ResNet101 instantiation

### DIFF
--- a/ML/Pytorch/CNN_architectures/pytorch_resnet.py
+++ b/ML/Pytorch/CNN_architectures/pytorch_resnet.py
@@ -165,7 +165,7 @@ def ResNet152(img_channel=3, num_classes=1000):
 def test():
     BATCH_SIZE = 4
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    net = ResNet101(img_channel=3, num_classes=1000).to(device)
+    net = ResNet101(img_channel=3, num_classes=1000)
     y = net(torch.randn(BATCH_SIZE, 3, 224, 224)).to(device)
     assert y.size() == torch.Size([BATCH_SIZE, 1000])
     print(y.size())


### PR DESCRIPTION
```python
Traceback (most recent call last):
  File "Machine-Learning-Collection/ML/Pytorch/CNN_architectures/pytorch_resnet.py", line 175, in <module>
    test()
  File "Machine-Learning-Collection/ML/Pytorch/CNN_architectures/pytorch_resnet.py", line 169, in test
    y = net(torch.randn(BATCH_SIZE, 3, 224, 224)).to(device)
  File "python3.9/site-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "python3.9/site-packages/torch/nn/modules/module.py", line 1750, in _call_impl
    return forward_call(*args, **kwargs)
  File "Machine-Learning-Collection/ML/Pytorch/CNN_architectures/pytorch_resnet.py", line 103, in forward
    x = self.conv1(x)
  File "python3.9/site-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "python3.9/site-packages/torch/nn/modules/module.py", line 1750, in _call_impl
    return forward_call(*args, **kwargs)
  File "python3.9/site-packages/torch/nn/modules/conv.py", line 554, in forward
    return self._conv_forward(input, self.weight, self.bias)
  File "python3.9/site-packages/torch/nn/modules/conv.py", line 549, in _conv_forward
    return F.conv2d(
RuntimeError: Input type (torch.FloatTensor) and weight type (torch.cuda.FloatTensor) should be the same or input should be a MKLDNN tensor and weight is a dense tensor
``` 

```python
    net = ResNet101(img_channel=3, num_classes=1000).to(device)
    y = net(torch.randn(BATCH_SIZE, 3, 224, 224)).to(device)
```
```python
    net = ResNet101(img_channel=3, num_classes=1000)
    y = net(torch.randn(BATCH_SIZE, 3, 224, 224)).to(device)
```